### PR TITLE
fixed dummy window indicator

### DIFF
--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -150,9 +150,9 @@ namespace skch
               Q.pop_back();
 
             //Push currentKmer and position to back of the queue
-            //0 indicates the dummy window # (will be updated later)
+            //-1 indicates the dummy window # (will be updated later)
             Q.push_back( std::make_pair(
-                  MinimizerInfo{currentKmer, seqCounter, 0, currentStrand},
+                  MinimizerInfo{currentKmer, seqCounter, -1, currentStrand},
                   i)); 
 
             //Select the minimizer from Q and put into index


### PR DESCRIPTION
Hi,

we forked `MashMap` to develop [wfmash](https://github.com/ekg/wfmash), a large-sequences aligner designed to accelerate the alignment step in the variation graphs induction.

Digging into how `MashMap` works, I ran into a possible small bug. If the first kmer of a sequence is considered as a minimizer, it will have position 0, and the same kmer will not be considered in other positions as 0 coincides with the dummy window indicator.

Using this sequence
```
>CIAO
CACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACACAC
```

and this command line

```
mashmap -r CIAO.fasta -q CIAO.fasta -s 500
```

I get

```
...
INFO, skch::Sketch::build, minimizers picked from reference = 1
...
```

with the `master`, and

```
...
INFO, skch::Sketch::build, minimizers picked from reference = 43
...
```

with the `fix_dummy_window_indicator`.

Could you please take a look?