### PR TITLE
make sure the hash is different from the null key value

### DIFF
--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -218,8 +218,10 @@ namespace skch
         for(auto &e : minimizerIndex)
         {
           // [hash value -> info about minimizer]
-          minimizerPosLookupIndex[e.hash].push_back( 
-              MinimizerMetaData{e.seqId, e.wpos, e.strand});
+          if (e.hash != 0) {
+              minimizerPosLookupIndex[e.hash].push_back(
+                      MinimizerMetaData{e.seqId, e.wpos, e.strand});
+          }
         }
 
         std::cout << "INFO, skch::Sketch::index, unique minimizers = " << minimizerPosLookupIndex.size() << std::endl;


### PR DESCRIPTION
Hi,

still digging into MashMap for [wfmash](https://github.com/ekg/wfmash) development, I ran into another problem. In the `minimizerPosLookupIndex` table, the empty key is set to 0, but then it is not checked that the hash is different from the empty value before inserting it, leading the `google::dense_hash_map` to complain.