### PR TITLE
Mashmap3

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1575,25 +1575,32 @@ namespace skch
           assert(e.refSeqId < this->refSketch.metadata.size());
 
           float fakeMapQ = e.nucIdentity == 1 ? 255 : std::round(-10.0 * std::log10(1-(e.nucIdentity)));
+          std::string sep = param.legacy_output ? " " : "\t";
 
           outstrm  << (param.filterMode == filter::ONETOONE ? qmetadata[e.querySeqId].name : queryName)
-                   << "\t" << e.queryLen
-                   << "\t" << e.queryStartPos
-                   << "\t" << e.queryEndPos
-                   << "\t" << (e.strand == strnd::FWD ? "+" : "-")
-                   << "\t" << this->refSketch.metadata[e.refSeqId].name
-                   << "\t" << this->refSketch.metadata[e.refSeqId].len
-                   << "\t" << e.refStartPos
-                   << "\t" << e.refEndPos
-                   << "\t" << e.conservedSketches
-                   << "\t" << e.blockLength
-                   << "\t" << fakeMapQ
-                   << "\t" << "id:f:" << e.nucIdentity * 100.0;
-          if (!param.mergeMappings) 
+                   << sep << e.queryLen
+                   << sep << e.queryStartPos
+                   << sep << e.queryEndPos - (param.legacy_output ? 1 : 0)
+                   << sep << (e.strand == strnd::FWD ? "+" : "-")
+                   << sep << this->refSketch.metadata[e.refSeqId].name
+                   << sep << this->refSketch.metadata[e.refSeqId].len
+                   << sep << e.refStartPos
+                   << sep << e.refEndPos - (param.legacy_output ? 1 : 0);
+
+          if (!param.legacy_output) 
           {
-            outstrm << "\t" << "jc:f:" << e.conservedSketches * 100.0 / e.sketchSize;
+            outstrm   << sep << e.conservedSketches
+                     << sep << e.blockLength
+                     << sep << fakeMapQ
+                     << sep << "id:f:" << e.nucIdentity;
+            if (!param.mergeMappings) 
+            {
+              outstrm << sep << "jc:f:" << e.conservedSketches / e.sketchSize;
+            }
+          } else
+          {
+            outstrm << sep << e.nucIdentity * 100.0;
           }
-              //<< "\t" << "nu:f:" << e.nucIdentityUpperBound;
 
 #ifdef DEBUG
           outstrm << std::endl;

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -67,6 +67,7 @@ struct Parameters
     bool world_minimizers;
     uint64_t sparsity_hash_threshold;                 // keep mappings that hash to <= this value
 
+    bool legacy_output;
     //std::unordered_set<std::string> high_freq_kmers;  //
 };
 

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -88,6 +88,7 @@ float confidence_interval = 0.95;                   // Confidence interval to re
 float percentage_identity = 0.85;                   // Percent identity in the mapping step
 float ANIDiff = 0.0;                                // Stage 1 ANI diff threshold
 float ANIDiffConf = 0.999;                          // ANI diff confidence
+std::string VERSION = "3.0.3";                      // Version of MashMap
 }
 }
 

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -121,6 +121,8 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
 'none' disables filtering", 
                     ArgvParser::OptionRequiresValue);
     cmd.defineOptionAlternative("filter_mode", "f");
+
+    cmd.defineOption("legacy", "MashMap2 output format");
   }
 
   /**
@@ -585,6 +587,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     else
       parameters.outFileName = "mashmap.out";
 
+    parameters.legacy_output = cmd.foundOption("legacy");
 
     printCmdOptions(parameters);
 

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -38,6 +38,9 @@ $ mashmap --rl reference_files_list.txt -q seq.fq [OPTIONS]");
 
     cmd.setHelpOption("h", "help", "Print this help page");
 
+    cmd.defineOption("version", "Print MashMap version");
+    cmd.defineOptionAlternative("version","v");
+
     cmd.defineOption("ref", "an input reference file (fasta/fastq)[.gz]", ArgvParser::OptionRequiresValue);
     cmd.defineOptionAlternative("ref","r");
 
@@ -237,6 +240,12 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     }
 
     std::stringstream str;
+
+    if(cmd.foundOption("version"))
+    {
+      std::cerr << fixed::VERSION << std::endl;
+      exit(0);
+    }
 
     //Parse reference files
     if(cmd.foundOption("ref"))


### PR DESCRIPTION
- Add `--legacy` flag for MashMap2 style output
- Add `-v`/`--version` flag 
- Output `id` and `jc` tags in `[0,1]` range instead of `[0, 100]`