### PR TITLE
v3.0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,17 +19,18 @@ endif()
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
 option(OPTIMIZE_FOR_NATIVE "Build with -march=native" ON)
+option(PROFILE             "Prevent inlining and add debug symbols" OFF)
 
 if (${CMAKE_BUILD_TYPE} MATCHES Release)
-    set(EXTRA_FLAGS "-Ofast ")
     if (OPTIMIZE_FOR_NATIVE)
       set(EXTRA_FLAGS "${EXTRA_FLAGS} -march=native")
     endif ()
-    set(CMAKE_CXX_FLAGS_RELEASE "-g -DNDEBUG") # reset CXX_FLAGS to replace -O3 with -Ofast
+    if (PROFILE)
+      set(EXTRA_FLAGS "${EXTRA_FLAGS} -g -fno-inline")
+    endif()
 endif ()
 
 if (${CMAKE_BUILD_TYPE} MATCHES Debug)
-    # Debug use the defaults - so commenting out:
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g")
 else()

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -238,12 +238,16 @@ namespace skch {
               }
             }
           }
-          std::for_each(sketched_vals.begin(), sketched_vals.end(),
-              [&minmerIndex](auto& pair) {
-              pair.second.strand = pair.second.strand > 0 ? strnd::FWD : (pair.second.strand == 0 ? strnd::AMBIG : strnd::REV);
-              minmerIndex.emplace_back(std::move(pair.second));
-          });
 
+          minmerIndex.resize(sketched_heap.size());
+          for (auto rev_it = minmerIndex.rbegin(); rev_it != minmerIndex.rend(); rev_it++)
+          {
+            *rev_it = (std::move(sketched_vals[sketched_heap.front()]));
+            (*rev_it).strand = (*rev_it).strand > 0 ? strnd::FWD : ((*rev_it).strand == 0 ? strnd::AMBIG : strnd::REV);
+
+            std::pop_heap(sketched_heap.begin(), sketched_heap.end());
+            sketched_heap.pop_back();
+          }
           return;
         }
         

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1595,7 +1595,7 @@ namespace skch
                      << sep << "id:f:" << e.nucIdentity;
             if (!param.mergeMappings) 
             {
-              outstrm << sep << "jc:f:" << e.conservedSketches / e.sketchSize;
+              outstrm << sep << "jc:f:" << float(e.conservedSketches) / e.sketchSize;
             }
           } else
           {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -554,6 +554,9 @@ namespace skch
             skch::Filter::query::filterMappings(output->readMappings, n_mappings);
         }
 
+        // remove self-mode don't-maps
+        this->filterSelfingLongToShorts(output->readMappings);
+
         //Make sure mapping boundary don't exceed sequence lengths
         this->mappingBoundarySanityCheck(input, output->readMappings);
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -554,12 +554,6 @@ namespace skch
             skch::Filter::query::filterMappings(output->readMappings, n_mappings);
         }
 
-        // remove self-mode don't-maps
-        this->filterSelfingLongToShorts(output->readMappings);
-
-        // remove alignments where the ratio between query and target length is < our identity threshold
-        this->filterFalseHighIdentity(output->readMappings);
-
         //Make sure mapping boundary don't exceed sequence lengths
         this->mappingBoundarySanityCheck(input, output->readMappings);
 

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -89,7 +89,7 @@ float confidence_interval = 0.95;                   // Confidence interval to re
 float percentage_identity = 0.85;                   // Percent identity in the mapping step
 float ANIDiff = 0.0;                                // Stage 1 ANI diff threshold
 float ANIDiffConf = 0.999;                          // ANI diff confidence
-std::string VERSION = "3.0.4";                      // Version of MashMap
+std::string VERSION = "3.0.5";                      // Version of MashMap
 }
 }
 

--- a/src/map/include/slidingMap.hpp
+++ b/src/map/include/slidingMap.hpp
@@ -101,10 +101,10 @@ namespace skch
         /**
          * @brief       Fills map with minimum 's' minmers in the query
          */
-        inline void init()
+        void init()
         {
           //Range of sketch in query
-          int idx = 0;
+          int idx = 1;
           for(auto it = Q.minmerTableQuery.begin(); it != Q.minmerTableQuery.end(); it++)
           {
             this->slidingWindowMinhashes[idx++] = slidingMapContainerValueType {
@@ -115,9 +115,6 @@ namespace skch
                 0}; // Active (shared)
           }
 
-          // Sort the hashes
-          std::sort(slidingWindowMinhashes.begin(), slidingWindowMinhashes.end(), slidingMapContainerValueType_comp);
-
           //Point pivot to last element in the map
           this->pivot = std::prev(this->slidingWindowMinhashes.end());
           pivRank = slidingWindowMinhashes.size() - 1;
@@ -125,7 +122,7 @@ namespace skch
 
       public:
 
-        inline void insert_minmer(const skch::MinmerInfo& mi)
+        void insert_minmer(const skch::MinmerInfo& mi)
         {
           // Find where minmer goes in vector
           auto insert_loc = std::lower_bound(


### PR DESCRIPTION
Changelog:

* Removed sanity-check filters that were actually dropping desired mappings
* Sort query minmers upon recruitment using the heap as opposed to sorting for every stage 1 hit
* Add `-DPROFILE` flag to compile w/ debug symbols and no inline (also removed `inline` keyword from some functions)
* Cast jaccard to float now that it is no longer multiplied by `100.0`. 