### PR TITLE
MashMap v3.0.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ endif ()
 if (${CMAKE_BUILD_TYPE} MATCHES Debug)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g")
+    add_compile_options(-fsanitize=address)
+    add_link_options(-fsanitize=address)
 else()
     # Use all standard-compliant optimizations - always add these:
     set (CMAKE_C_FLAGS "${OpenMP_C_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS}")

--- a/src/common/progress.hpp
+++ b/src/common/progress.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <iostream>
 #include <string>
 #include <atomic>

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cmath>
 #include <string>
 

--- a/src/map/include/base_types.hpp
+++ b/src/map/include/base_types.hpp
@@ -166,7 +166,7 @@ namespace skch
 
                                                         //--for split read mapping
 
-    long double seqComplexity;                               // Estimated sequence complexity
+    long double kmerComplexity;                               // Estimated sequence complexity
     int n_merged;                                       // how many mappings we've merged into this one
     offset_t splitMappingId;                            // To identify split mappings that are chained
     uint8_t discard;                                    // set to 1 for deletion
@@ -276,7 +276,7 @@ namespace skch
       MinmerVec minmerTableQuery;         //Vector of minmers in the query
       MinmerVec seedHits;                 //Vector of minmers in the reference
       int refGroup;                       //Prefix group of sequence
-      float seqComplexity;                //Estimated sequence complexity
+      float kmerComplexity;                //Estimated sequence complexity
     };
 }
 

--- a/src/map/include/base_types.hpp
+++ b/src/map/include/base_types.hpp
@@ -225,12 +225,9 @@ namespace skch
           , seqName(id) { }
   };
 
-  struct InputSeqProgContainer
+  struct InputSeqProgContainer : InputSeqContainer
   {
-    seqno_t seqCounter;                         //sequence counter
-    offset_t len;                               //sequence length
-    std::string seq;                            //sequence string
-    std::string seqName;                        //sequence id
+    using InputSeqContainer::InputSeqContainer;
     progress_meter::ProgressMeter& progress;    //progress meter (shared)
                                                 
 
@@ -241,10 +238,7 @@ namespace skch
      * @param[in] len       length of sequence
      */
       InputSeqProgContainer(const std::string& s, const std::string& id, seqno_t seqcount, progress_meter::ProgressMeter& pm)
-          : seqCounter(seqcount)
-          , len(s.length())
-          , seq(s)
-          , seqName(id)
+          : InputSeqContainer(s, id, seqcount)
           , progress(pm) { }
   };
 

--- a/src/map/include/base_types.hpp
+++ b/src/map/include/base_types.hpp
@@ -10,6 +10,7 @@
 #include <tuple>
 #include <vector>
 #include <chrono>
+#include "common/progress.hpp"
 
 namespace skch
 {
@@ -204,10 +205,11 @@ namespace skch
   //Container to save copy of kseq object
   struct InputSeqContainer
   {
-    seqno_t seqCounter;                 //sequence counter
-    offset_t len;                       //sequence length
-    std::string seq;                    //sequence string
-    std::string seqName;                //sequence id
+    seqno_t seqCounter;                         //sequence counter
+    offset_t len;                               //sequence length
+    std::string seq;                            //sequence string
+    std::string seqName;                        //sequence id
+
 
     /*
      * @brief               constructor
@@ -216,11 +218,35 @@ namespace skch
      * @param[in] len       length of sequence
      */
       InputSeqContainer(const std::string& s, const std::string& id, seqno_t seqcount)
-          : seq(s)
-          , seqName(id)
+          : seqCounter(seqcount)
           , len(s.length())
-          , seqCounter(seqcount) { }
+          , seq(s)
+          , seqName(id) { }
   };
+
+  struct InputSeqProgContainer
+  {
+    seqno_t seqCounter;                         //sequence counter
+    offset_t len;                               //sequence length
+    std::string seq;                            //sequence string
+    std::string seqName;                        //sequence id
+    progress_meter::ProgressMeter& progress;    //progress meter (shared)
+                                                
+
+    /*
+     * @brief               constructor
+     * @param[in] kseq_seq  complete read or reference sequence
+     * @param[in] kseq_id   sequence id name
+     * @param[in] len       length of sequence
+     */
+      InputSeqProgContainer(const std::string& s, const std::string& id, seqno_t seqcount, progress_meter::ProgressMeter& pm)
+          : seqCounter(seqcount)
+          , len(s.length())
+          , seq(s)
+          , seqName(id)
+          , progress(pm) { }
+  };
+
 
   //Output type of map function
   struct MapModuleOutput
@@ -248,6 +274,7 @@ namespace skch
       std::string seqName;                //sequence name
       MinmerVec minmerTableQuery;         //Vector of minmers in the query
       MinmerVec seedHits;                 //Vector of minmers in the reference
+      int refGroup;                       //Prefix group of sequence
     };
 }
 

--- a/src/map/include/base_types.hpp
+++ b/src/map/include/base_types.hpp
@@ -166,6 +166,7 @@ namespace skch
 
                                                         //--for split read mapping
 
+    long double seqComplexity;                               // Estimated sequence complexity
     int n_merged;                                       // how many mappings we've merged into this one
     offset_t splitMappingId;                            // To identify split mappings that are chained
     uint8_t discard;                                    // set to 1 for deletion
@@ -275,6 +276,7 @@ namespace skch
       MinmerVec minmerTableQuery;         //Vector of minmers in the query
       MinmerVec seedHits;                 //Vector of minmers in the reference
       int refGroup;                       //Prefix group of sequence
+      float seqComplexity;                //Estimated sequence complexity
     };
 }
 

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -16,7 +16,6 @@
 #include <numeric>
 #include <queue>
 #include <sstream>
-#include <string_view>
 
 //Own includes
 #include "map/include/map_parameters.hpp"
@@ -189,7 +188,6 @@ namespace skch {
           sketched_heap.reserve(sketchSize+1);
             
           // Get distance until last "N"
-          std::string_view first_kmer(seq, kmerSize);
           int ambig_kmer_count = 0;
           for (int i = kmerSize - 1; i >= 0; i--)
           {

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -16,6 +16,7 @@
 #include <numeric>
 #include <queue>
 #include <sstream>
+#include <string_view>
 
 //Own includes
 #include "map/include/map_parameters.hpp"
@@ -186,9 +187,26 @@ namespace skch {
           ankerl::unordered_dense::map<hash_t, MinmerInfo> sketched_vals;
           std::vector<hash_t> sketched_heap;
           sketched_heap.reserve(sketchSize+1);
+            
+          // Get distance until last "N"
+          std::string_view first_kmer(seq, kmerSize);
+          int ambig_kmer_count = 0;
+          for (int i = kmerSize - 1; i >= 0; i--)
+          {
+            if (seq[i] == 'N')
+            {
+                ambig_kmer_count = i+1;
+                break;
+            }    
+          } 
 
           for(offset_t i = 0; i < len - kmerSize + 1; i++)
           {
+
+            if (seq[i+kmerSize-1] == 'N')
+            {
+              ambig_kmer_count = kmerSize;
+            }
             //Hash kmers
             hash_t hashFwd = CommonFunc::getHash(seq + i, kmerSize); 
             hash_t hashBwd;
@@ -199,7 +217,7 @@ namespace skch {
               hashBwd = std::numeric_limits<hash_t>::max();   //Pick a dummy high value so that it is ignored later
 
             //Consider non-symmetric kmers only
-            if(hashBwd != hashFwd)
+            if(hashBwd != hashFwd && ambig_kmer_count == 0)
             {
               //Take minimum value of kmer and its reverse complement
               hash_t currentKmer = std::min(hashFwd, hashBwd);
@@ -236,6 +254,10 @@ namespace skch {
                   sketched_vals[currentKmer].strand += currentStrand == strnd::FWD ? 1 : -1;
                 }
               }
+            }
+            if (ambig_kmer_count > 0)
+            {
+              ambig_kmer_count--;
             }
           }
 
@@ -293,6 +315,10 @@ namespace skch {
 
             //if(alphabetSize == 4) //not protein
               //CommonFunc::reverseComplement(seq, seqRev.get(), len);
+            
+            // Get distance until last "N"
+            int ambig_kmer_count = 0;
+
 
             for(offset_t i = 0; i < len - kmerSize + 1; i++)
             {
@@ -369,8 +395,12 @@ namespace skch {
                 Q.pop_front();
               }
 
+              if (seq[i+kmerSize-1] == 'N')
+              {
+                ambig_kmer_count = kmerSize;
+              }
               //Consider non-symmetric kmers only
-              if(hashBwd != hashFwd)
+              if(hashBwd != hashFwd && ambig_kmer_count == 0)
               {
                 // Add current hash to window
                 Q.push_back(std::make_tuple(currentKmer, currentStrand, i)); 
@@ -399,6 +429,11 @@ namespace skch {
                   std::push_heap(heapWindow.begin(), heapWindow.end(), KIHeap_cmp);
                 }
               }
+              if (ambig_kmer_count > 0)
+              {
+                ambig_kmer_count--;
+              }
+              
 
 
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -674,9 +674,11 @@ namespace skch
         // remove self-mode don't-maps
         this->filterSelfingLongToShorts(output->readMappings);
         
-        // Currently causing issues, disabling for now
         // remove alignments where the ratio between query and target length is < our identity threshold
-        //this->filterFalseHighIdentity(output->readMappings);
+        if (param.filterLengthMismatches)
+        {
+          this->filterFalseHighIdentity(output->readMappings);
+        }
 
         //Make sure mapping boundary don't exceed sequence lengths
         this->mappingBoundarySanityCheck(input, output->readMappings);

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1589,7 +1589,7 @@ namespace skch
             outstrm  << sep << e.conservedSketches
                      << sep << e.blockLength
                      << sep << fakeMapQ
-                     << sep << "id:f:" << e.nucIdentity;
+                     << sep << "id:f:" << (param.report_ANI_percentage ? 100.0 : 1.0) * e.nucIdentity;
             if (!param.mergeMappings) 
             {
               outstrm << sep << "jc:f:" << float(e.conservedSketches) / e.sketchSize;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1177,19 +1177,6 @@ namespace skch
 
             l2_vec.clear();
             computeL2MappedRegions(Q, candidateLocus, l2_vec);
-            //if (l2_vec.size() > 1)
-            //{
-              //std::cerr <<  candidateLocus.seqId << ":"
-               //<< candidateLocus.rangeStartPos << "--" << candidateLocus.rangeEndPos  << " == " << candidateLocus.rangeEndPos - candidateLocus.rangeStartPos
-               //<< std::endl;
-              //std::cerr << candidateLocus.intersectionSize
-               //<< "-->" << sketchCutoffs[candidateLocus.intersectionSize] << std::endl;
-              //for (const auto& l2 : l2_vec)
-              //{
-                //std::cerr << l2.optimalStart << "--" << l2.optimalEnd << "\t" << l2.sharedSketchSize << std::endl;  
-              //}
-              //std::cerr << std::endl;
-            //}
 
             for (auto& l2 : l2_vec) 
             {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -554,7 +554,7 @@ namespace skch
         MappingResultsVector_t unfilteredMappings;
         int refGroup = this->getRefGroup(input->seqName);
 
-        if(! param.split || input->len <= param.segLength)
+        if(! param.split || input->len <= param.segLength || input->len <= param.block_length)
         {
           QueryMetaData <MinVec_Type> Q;
           Q.seq = &(input->seq)[0u];

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -646,15 +646,6 @@ namespace skch
                           param.numMappingsForShortSequence
                           : param.numMappingsForSegment) - 1;
 
-        // TODO this should happen after chaining i think
-        if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) {                      
-          if (!param.stage1_topANI_filter) {
-            filterByGroup(unfilteredMappings, output->readMappings, n_mappings*100);
-            std::swap(unfilteredMappings, output->readMappings);
-            output->readMappings.clear();
-          }
-        }
-
         if (split_mapping) 
         {
           if (param.mergeMappings) 
@@ -662,18 +653,19 @@ namespace skch
             // hardcore merge using the chain gap
             mergeMappingsInRange(unfilteredMappings, param.chain_gap);
             //mergeMappings(unfilteredMappings);
-            if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) {                      
-              MappingResultsVector_t tempMappings;
-              tempMappings.reserve(output->readMappings.size());
-              filterByGroup(unfilteredMappings, tempMappings, n_mappings);
-              std::swap(tempMappings, unfilteredMappings);
-            }
             if (input->len >= param.block_length) 
             {
               // remove short chains that didn't exceed block length
               filterWeakMappings(unfilteredMappings, std::floor(param.block_length / param.segLength));
             }
           }
+        }
+
+        if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) {                      
+          MappingResultsVector_t tempMappings;
+          tempMappings.reserve(output->readMappings.size());
+          filterByGroup(unfilteredMappings, tempMappings, n_mappings);
+          std::swap(tempMappings, unfilteredMappings);
         }
 
         std::swap(output->readMappings, unfilteredMappings);

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -60,6 +60,7 @@ struct Parameters
     bool keep_low_pct_id;                             //true if we should keep mappings whose estimated identity < percentageIdentity
     bool report_ANI_percentage;                       //true if ANI should be in [0,100] as opposed to [0,1] (this is necessary for wfmash
     bool filterLengthMismatches;                      //true if filtering out length mismatches
+    float kmerComplexityThreshold;                    //minimum kmer complexity to consider (default 0)
 
 
     int sketchSize;

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -91,7 +91,7 @@ float confidence_interval = 0.95;                   // Confidence interval to re
 float percentage_identity = 0.85;                   // Percent identity in the mapping step
 float ANIDiff = 0.0;                                // Stage 1 ANI diff threshold
 float ANIDiffConf = 0.999;                          // ANI diff confidence
-std::string VERSION = "3.0.5";                      // Version of MashMap
+std::string VERSION = "3.0.6";                      // Version of MashMap
 }
 }
 

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -58,6 +58,8 @@ struct Parameters
     char prefix_delim;                                //the prefix delimiter
     bool mergeMappings;                               //if we should merge consecutive segment mappings
     bool keep_low_pct_id;                             //true if we should keep mappings whose estimated identity < percentageIdentity
+    bool report_ANI_percentage;                       //true if ANI should be in [0,100] as opposed to [0,1] (this is necessary for wfmash
+
 
     int sketchSize;
     bool use_spaced_seeds;                            //

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -59,6 +59,7 @@ struct Parameters
     bool mergeMappings;                               //if we should merge consecutive segment mappings
     bool keep_low_pct_id;                             //true if we should keep mappings whose estimated identity < percentageIdentity
     bool report_ANI_percentage;                       //true if ANI should be in [0,100] as opposed to [0,1] (this is necessary for wfmash
+    bool filterLengthMismatches;                      //true if filtering out length mismatches
 
 
     int sketchSize;

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -95,6 +95,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     cmd.defineOptionAlternative("kmer","k");
 
     cmd.defineOption("kmerThreshold", "ignore the top \% most-frequent kmer window [default: 0.001]", ArgvParser::OptionRequiresValue);
+    cmd.defineOption("kmerComplexity", "threshold for kmer complexity [0, 1] [default : 0.0]", ArgvParser::OptionRequiresValue);
 
 
     //cmd.defineOption("shortenCandidateRegions", "Only compute rolling minhash score for small regions around positions where the intersection of reference and query minmers is locally maximal. Results in slighty faster runtimes at the cost of mapping placement and ANI prediction.");
@@ -508,6 +509,16 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     }
     else
       parameters.percentageIdentity = 0.85;
+    str.clear();
+
+    if(cmd.foundOption("kmerComplexity"))
+    {
+      str << cmd.optionValue("kmerComplexity");
+      str >> parameters.kmerComplexityThreshold;
+      str.clear();
+    }
+    else
+      parameters.kmerComplexityThreshold = 0.0;
     str.clear();
 
 

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -123,6 +123,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     cmd.defineOptionAlternative("filter_mode", "f");
 
     cmd.defineOption("legacy", "MashMap2 output format");
+    cmd.defineOption("reportPercentage", "Report predicted ANI values in [0, 100] instead of [0,1] (necessary for use with wfmash)");
   }
 
   /**
@@ -596,6 +597,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
       parameters.outFileName = "mashmap.out";
 
     parameters.legacy_output = cmd.foundOption("legacy");
+    parameters.report_ANI_percentage = cmd.foundOption("reportPercentage");
 
     printCmdOptions(parameters);
 

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -103,6 +103,8 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     cmd.defineOption("hgFilterAniDiff", "Filter out mappings unlikely to be this ANI less than the best mapping [default: 0.0]", ArgvParser::OptionRequiresValue);
     cmd.defineOption("hgFilterConf", "Confidence value for the hypergeometric filtering [default: 0.999]", ArgvParser::OptionRequiresValue);
 
+    cmd.defineOption("filterLengthMismatches", "Filter mappings where the ratio of reference/query mapped lengths disagrees with the ANI threshold");
+
     cmd.defineOption("skipSelf", "skip self mappings when the query and target name is the same (for all-vs-all mode)");
     cmd.defineOptionAlternative("skipSelf", "X");
 
@@ -346,6 +348,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     //Do not expose the option to set protein alphabet in mashmap
     //parameters.alphabetSize = 20;
     
+    parameters.filterLengthMismatches = cmd.foundOption("filterLengthMismatches"); 
     parameters.stage1_topANI_filter = !cmd.foundOption("noHgFilter"); 
 
     if(cmd.foundOption("filter_mode"))


### PR DESCRIPTION
* `--splitPrefix` now performs the filtering on each prefix-group independently. 
* Does not sketch or winnow k-mers w/ ambiguous nucleotides. 
* Added `kc:f`  tag for the estimated k-mer complexity, defined as the ratio of the estimated number of distinct k-mers in a segment to the total number of k-mers in a segment (this estimate can be greater than `1.0`).
* Added a flag `--kmerComplexity x` to filter out segments with estimated kmer complexity less than `x`.
* Mapping progress now updates for each segment mapped, as opposed to each contig mapped. 
* Added `--reportPercentage` option to report ANI as a percentage instead of in `[0, 1]` range (necessary for use w/ wfmash)
* Fixes #54 
* Does not split sequences smaller than the block length.
* Added address sanitizer for `Debug` build

