### PR TITLE
V3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ endif()
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
 option(OPTIMIZE_FOR_NATIVE "Build with -march=native" ON)
+option(LARGE_CONTIG "Use 64-bit integers instead of 32 bit for sequence coordinates" OFF)
+if (LARGE_CONTIG)
+  add_definitions(-DLARGE_CONTIG)
+endif()
 option(PROFILE             "Prevent inlining and add debug symbols" OFF)
 
 if (${CMAKE_BUILD_TYPE} MATCHES Release)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ target_link_libraries(mashmap
   gslcblas
   m
   pthread
+  hts
   #rt
   z
   #assert
@@ -92,6 +93,7 @@ target_link_libraries(mashmap-align
   gslcblas
   m
   pthread
+  hts
   #rt
   z
   #assert

--- a/src/common/seqiter.hpp
+++ b/src/common/seqiter.hpp
@@ -2,53 +2,111 @@
 
 #include <string>
 #include <functional>
+#include <cassert>
+#include <unordered_set>
 #include "gzstream.h"
+#include <htslib/faidx.h>
 
 namespace seqiter {
 
-void for_each_seq_in_file(
-    const std::string& filename,
-    const std::function<void(const std::string&, const std::string&)>& func) {
-    // detect file type
-    bool input_is_fasta = false;
-    bool input_is_fastq = false;
-    std::string line;
-    igzstream in(filename.c_str());
-    std::getline(in, line);
-    if (line[0] == '>') {
-        input_is_fasta = true;
-    } else if (line[0] == '@') {
-        input_is_fastq = true;
-    } else {
-        std::cerr << "[mashmap::for_each_seq_in_file] unknown file format given to seqiter" << std::endl;
-        assert(false);
-        exit(1);
-    }
-    if (input_is_fasta) {
-        while (in.good()) {
-            std::string name = line.substr(1, line.find(" ")-1);
-            std::string seq;
-            while (std::getline(in, line)) {
-                if (line[0] == '>') {
-                    // this is the header of the next sequence
-                    break;
-                } else {
-                    seq.append(line);
-                }
-            }
-            func(name, seq);
-        }
-    } else if (input_is_fastq) {
-        while (in.good()) {
-            std::string name = line.substr(1, line.find(" ")-1);
-            std::string seq;
-            std::getline(in, seq); // sequence
-            std::getline(in, line); // delimiter
-            std::getline(in, line); // quality
-            std::getline(in, line); // next header
-            func(name, seq);
-        }
-    }
+bool fai_index_exists(const std::string& filename) {
+  // Check if .fai file exists
+  std::ifstream f(filename + ".fai");
+  return f.good();
 }
 
+void for_each_seq_in_file(
+    const std::string& filename,
+	const std::unordered_set<std::string>& keep_seq,
+	const std::string& keep_prefix,
+    const std::function<void(const std::string&, const std::string&)>& func) {
+
+    if ((!keep_seq.empty() || !keep_prefix.empty())
+		&& fai_index_exists(filename)) {
+        // Use index
+		// Handle keep_prefix
+		auto faid = fai_load(filename.c_str());
+        if (!keep_prefix.empty()) {
+			// iterate over lines in the fai file
+			std::string line;
+			std::ifstream in(filename + ".fai");
+			while (std::getline(in, line)) {
+				std::string name = line.substr(0, line.find("\t"));
+				if (strncmp(name.c_str(), keep_prefix.c_str(), keep_prefix.size()) == 0) {
+					int64_t len = 0;
+					char * seq = faidx_fetch_seq64(
+						faid, name.c_str(), 0, INT_MAX, &len);
+					func(name, std::string(seq, len));
+					free(seq);
+				}
+			}
+        }
+		// Handle keep_seq
+        for (const auto& name : keep_seq) {
+            int64_t len;
+            char *seq = faidx_fetch_seq64(
+				faid, name.c_str(), 0, INT_MAX, &len);
+            if (!seq) {
+                std::cerr << "[wfmash::for_each_seq_in_file] could not fetch " << name << " from index" << std::endl;
+                continue;
+            }
+            func(name, std::string(seq, len));
+            free(seq);
+        }
+		fai_destroy(faid); // Free FAI index
+	} else {
+		// no index available
+		// detect file type
+		bool input_is_fasta = false;
+		bool input_is_fastq = false;
+		std::string line;
+		igzstream in(filename.c_str());
+		std::getline(in, line);
+		if (line[0] == '>') {
+			input_is_fasta = true;
+		} else if (line[0] == '@') {
+			input_is_fastq = true;
+		} else {
+			std::cerr << "[wfmash::for_each_seq_in_file] unknown file format given to seqiter" << std::endl;
+			assert(false);
+			exit(1);
+		}
+		if (input_is_fasta) {
+			while (in.good()) {
+				std::string name = line.substr(1, line.find(" ")-1);
+				std::string seq;
+				bool keep = (keep_prefix.empty() || name.substr(0, keep_prefix.length()) == keep_prefix)
+					&& (keep_seq.empty() || keep_seq.find(name) != keep_seq.end());
+				while (std::getline(in, line)) {
+					if (line[0] == '>') {
+						// this is the header of the next sequence
+						break;
+					} else {
+						if (keep) {
+							seq.append(line);
+						}
+					}
+				}
+				if (keep) {
+					func(name, seq);
+				}
+			}
+		} else if (input_is_fastq) {
+			while (in.good()) {
+				std::string name = line.substr(1, line.find(" ")-1);
+				std::string seq;
+				bool keep = (keep_prefix.empty() || name.substr(0, keep_prefix.length()) == keep_prefix)
+					&& (keep_seq.empty() || keep_seq.find(name) != keep_seq.end());
+				std::getline(in, seq); // sequence
+				std::getline(in, line); // delimiter
+				std::getline(in, line); // quality
+				std::getline(in, line); // next header
+				if (keep) {
+					func(name, seq);
+				}
+			}
+		}
+	}
 }
+
+} // namespace seqiter

--- a/src/common/seqiter.hpp
+++ b/src/common/seqiter.hpp
@@ -17,96 +17,93 @@ bool fai_index_exists(const std::string& filename) {
 
 void for_each_seq_in_file(
     const std::string& filename,
-	const std::unordered_set<std::string>& keep_seq,
-	const std::string& keep_prefix,
+    const std::unordered_set<std::string>& keep_seq,
+    const std::string& keep_prefix,
     const std::function<void(const std::string&, const std::string&)>& func) {
 
     if ((!keep_seq.empty() || !keep_prefix.empty())
-		&& fai_index_exists(filename)) {
+          && fai_index_exists(filename)) {
         // Use index
-		// Handle keep_prefix
-		auto faid = fai_load(filename.c_str());
+        // Handle keep_prefix
+        std::unordered_set<std::string> found_seq;
+        auto faid = fai_load(filename.c_str());
         if (!keep_prefix.empty()) {
-			// iterate over lines in the fai file
-			std::string line;
-			std::ifstream in(filename + ".fai");
-			while (std::getline(in, line)) {
-				std::string name = line.substr(0, line.find("\t"));
-				if (strncmp(name.c_str(), keep_prefix.c_str(), keep_prefix.size()) == 0) {
-					int64_t len = 0;
-					char * seq = faidx_fetch_seq64(
-						faid, name.c_str(), 0, INT_MAX, &len);
-					func(name, std::string(seq, len));
-					free(seq);
-				}
-			}
-        }
-		// Handle keep_seq
-        for (const auto& name : keep_seq) {
-            int64_t len;
-            char *seq = faidx_fetch_seq64(
-				faid, name.c_str(), 0, INT_MAX, &len);
-            if (!seq) {
-                std::cerr << "[wfmash::for_each_seq_in_file] could not fetch " << name << " from index" << std::endl;
-                continue;
+            // iterate over lines in the fai file
+            std::string line;
+            std::ifstream in(filename + ".fai");
+            while (std::getline(in, line)) {
+                std::string name = line.substr(0, line.find("\t"));
+                char* seq;
+                int64_t len = 0;
+                if (strncmp(name.c_str(), keep_prefix.c_str(), keep_prefix.size()) == 0
+                    || keep_seq.find(name) != keep_seq.end()) {
+                    found_seq.insert(name);
+                    seq = faidx_fetch_seq64(
+                        faid, name.c_str(), 0, INT_MAX, &len);
+                    func(name, std::string(seq, len));
+                    free(seq);
+                } else {
+                    func(name, "");
+                }
             }
-            func(name, std::string(seq, len));
-            free(seq);
         }
-		fai_destroy(faid); // Free FAI index
-	} else {
-		// no index available
-		// detect file type
-		bool input_is_fasta = false;
-		bool input_is_fastq = false;
-		std::string line;
-		igzstream in(filename.c_str());
-		std::getline(in, line);
-		if (line[0] == '>') {
-			input_is_fasta = true;
-		} else if (line[0] == '@') {
-			input_is_fastq = true;
-		} else {
-			std::cerr << "[wfmash::for_each_seq_in_file] unknown file format given to seqiter" << std::endl;
-			assert(false);
-			exit(1);
-		}
-		if (input_is_fasta) {
-			while (in.good()) {
-				std::string name = line.substr(1, line.find(" ")-1);
-				std::string seq;
-				bool keep = (keep_prefix.empty() || name.substr(0, keep_prefix.length()) == keep_prefix)
-					&& (keep_seq.empty() || keep_seq.find(name) != keep_seq.end());
-				while (std::getline(in, line)) {
-					if (line[0] == '>') {
-						// this is the header of the next sequence
-						break;
-					} else {
-						if (keep) {
-							seq.append(line);
-						}
-					}
-				}
-				if (keep) {
-					func(name, seq);
-				}
-			}
-		} else if (input_is_fastq) {
-			while (in.good()) {
-				std::string name = line.substr(1, line.find(" ")-1);
-				std::string seq;
-				bool keep = (keep_prefix.empty() || name.substr(0, keep_prefix.length()) == keep_prefix)
-					&& (keep_seq.empty() || keep_seq.find(name) != keep_seq.end());
-				std::getline(in, seq); // sequence
-				std::getline(in, line); // delimiter
-				std::getline(in, line); // quality
-				std::getline(in, line); // next header
-				if (keep) {
-					func(name, seq);
-				}
-			}
-		}
-	}
+        // Handle keep_seq
+        for (const auto& name : keep_seq) {
+            if (found_seq.find(name) == found_seq.end())
+            {
+                std::cerr << "[wfmash::for_each_seq_in_file] could not fetch " << name << " from index" << std::endl;
+            }
+        }
+        fai_destroy(faid); // Free FAI index
+    } else {
+        // no index available
+        // detect file type
+        bool input_is_fasta = false;
+        bool input_is_fastq = false;
+        std::string line;
+        igzstream in(filename.c_str());
+        std::getline(in, line);
+        if (line[0] == '>') {
+            input_is_fasta = true;
+        } else if (line[0] == '@') {
+            input_is_fastq = true;
+        } else {
+            std::cerr << "[wfmash::for_each_seq_in_file] unknown file format given to seqiter" << std::endl;
+            assert(false);
+            exit(1);
+        }
+        if (input_is_fasta) {
+            while (in.good()) {
+                std::string name = line.substr(1, line.find(" ")-1);
+                std::string seq;
+                bool keep = (keep_prefix.empty() || name.substr(0, keep_prefix.length()) == keep_prefix)
+                    && (keep_seq.empty() || keep_seq.find(name) != keep_seq.end());
+                while (std::getline(in, line)) {
+                    if (line[0] == '>') {
+                        // this is the header of the next sequence
+                        break;
+                    } else {
+                        if (keep) {
+                            seq.append(line);
+                        }
+                    }
+                }
+                func(name, seq);
+            }
+        } else if (input_is_fastq) {
+            while (in.good()) {
+                std::string name = line.substr(1, line.find(" ")-1);
+                std::string seq;
+                bool keep = (keep_prefix.empty() || name.substr(0, keep_prefix.length()) == keep_prefix)
+                    && (keep_seq.empty() || keep_seq.find(name) != keep_seq.end());
+                std::getline(in, seq); // sequence
+                std::getline(in, line); // delimiter
+                std::getline(in, line); // quality
+                std::getline(in, line); // next header
+                func(name, keep ? seq : "");
+            }
+        }
+    }
 }
 
 } // namespace seqiter

--- a/src/map/include/base_types.hpp
+++ b/src/map/include/base_types.hpp
@@ -15,8 +15,12 @@
 namespace skch
 {
   typedef uint64_t hash_t;    //hash type
+#ifdef LARGE_CONTIG
   typedef int64_t offset_t;   //position within sequence
-  typedef int32_t seqno_t;   //sequence counter in file
+#else
+  typedef int32_t offset_t;   //position within sequence
+#endif
+  typedef int32_t seqno_t;    //sequence counter in file
   typedef int16_t strand_t;   //sequence strand 
   typedef int8_t side_t;      //sequence strand 
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -863,8 +863,9 @@ namespace skch
             const IP_const_iterator ip_it = pq.front().it;
             const auto& ref = this->refSketch.metadata[ip_it->seqId];
             if ((!param.skip_prefix && !param.skip_self)
-                || ((Q.fullLen <= ref.len)
-                  && ((param.skip_self && Q.seqName != ref.name)
+                || (
+                  //(Q.fullLen <= ref.len) &&
+                  ((param.skip_self && Q.seqName != ref.name)
                       || (param.skip_prefix && this->refIdGroup[ip_it->seqId] != Q.refGroup)))
             ) {
               intervalPoints.push_back(*ip_it);

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1107,7 +1107,7 @@ namespace skch
           getSeedHits(Q);
 
           //Catch all NNNNNN case
-          if (Q.sketchSize == 0) {
+          if (Q.sketchSize == 0 || Q.kmerComplexity < param.kmerComplexityThreshold) {
             return;
           }
 
@@ -1192,9 +1192,8 @@ namespace skch
               // if we are in all-vs-all mode, it isn't a self-mapping,
               // and if we are self-mapping, the query is shorter than the target
               const auto& ref = this->refSketch.metadata[l2.seqId];
-              if((Q.kmerComplexity >= param.kmerComplexityThreshold)
-                  && ((param.keep_low_pct_id && nucIdentityUpperBound >= param.percentageIdentity)
-                  || nucIdentity >= param.percentageIdentity))
+              if((param.keep_low_pct_id && nucIdentityUpperBound >= param.percentageIdentity)
+                  || nucIdentity >= param.percentageIdentity)
               {
                 //Track the best jaccard numerator
                 bestJaccardNumerator = std::max<double>(bestJaccardNumerator, l2.sharedSketchSize);

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -555,7 +555,7 @@ namespace skch
         MappingResultsVector_t unfilteredMappings;
         int refGroup = this->getRefGroup(input->seqName);
 
-        if(! param.split || input->len <= param.segLength || input->len <= param.block_length)
+        if(! param.split || input->len <= param.segLength)
         {
           QueryMetaData <MinVec_Type> Q;
           Q.seq = &(input->seq)[0u];
@@ -654,11 +654,9 @@ namespace skch
             // hardcore merge using the chain gap
             mergeMappingsInRange(unfilteredMappings, param.chain_gap);
             //mergeMappings(unfilteredMappings);
-            if (input->len >= param.block_length) 
-            {
-              // remove short chains that didn't exceed block length
-              filterWeakMappings(unfilteredMappings, std::floor(param.block_length / param.segLength));
-            }
+
+            // remove short chains that didn't exceed block length
+            filterWeakMappings(unfilteredMappings, std::floor(param.block_length / param.segLength));
           }
         }
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -991,7 +991,8 @@ namespace skch
           int prevPrevOverlap = 0;
 
           // Need to keep track of two positions, as the previous one will be the local optimum
-          SeqCoord prevPos, currentPos;
+          SeqCoord prevPos;
+          SeqCoord currentPos{leadingIt->seqId, leadingIt->pos};
 
 
           while (leadingIt != ip_end)

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -293,7 +293,7 @@ namespace skch
                 // if not, warn that this is expensive
                 std::cerr << "[mashmap::skch::Map::mapQuery] WARNING, no .fai index found for " << fileName << ", reading the file to sum sequence length (slow)" << std::endl;
                 seqiter::for_each_seq_in_file(
-                    fileName,
+                    fileName, {}, "",
                     [&](const std::string& seq_name,
                         const std::string& seq) {
                         ++total_seqs;
@@ -312,7 +312,7 @@ namespace skch
 #endif
 
             seqiter::for_each_seq_in_file(
-                fileName,
+                fileName, {}, "",
                 [&](const std::string& seq_name,
                     const std::string& seq) {
                     // todo: offset_t is an 32-bit integer, which could cause problems

--- a/src/map/include/filter.hpp
+++ b/src/map/include/filter.hpp
@@ -31,6 +31,7 @@ namespace skch
      * @namespace skch::filter::query
      * @brief     filter routines (best for query sequence)
      */
+
     namespace query
     {
       //helper functions for executing plane sweep over query sequence
@@ -40,29 +41,29 @@ namespace skch
 
         Helper(MappingResultsVector_t &v) : vec(v) {}
 
-        double get_score(const int& x) { return vec[x].qlen() * vec[x].nucIdentity; }
+        double get_score(const int x) const {return vec[x].nucIdentity; }
 
         //Greater than comparison by score and begin position
         //used to define order in BST
-        bool operator ()(const int &x, const int &y) const {
+        bool operator ()(const int x, const int y) const {
 
           assert(x < vec.size());
           assert(y < vec.size());
 
-          auto x_score = vec[x].qlen() * vec[x].nucIdentity;
-          auto y_score = vec[y].qlen() * vec[y].nucIdentity;
+          auto x_score = get_score(x);
+          auto y_score = get_score(y);
 
           return std::tie(x_score, vec[x].queryStartPos, vec[x].refSeqId) > std::tie(y_score, vec[y].queryStartPos, vec[y].refSeqId);
         }
 
         //Greater than comparison by score
-        bool greater_score(const int &x, const int &y) {
+        bool greater_score(const int x, const int y) const {
 
           assert(x < vec.size());
           assert(y < vec.size());
 
-          auto x_score = vec[x].qlen() * vec[x].nucIdentity;
-          auto y_score = vec[y].qlen() * vec[y].nucIdentity;
+          auto x_score = get_score(x);
+          auto y_score = get_score(y);
 
           return x_score > y_score;
         }
@@ -123,7 +124,7 @@ namespace skch
           for(int i = 0; i < readMappings.size(); i++)
           {
             eventSchedule.emplace_back (readMappings[i].queryStartPos, event::BEGIN, i);
-            eventSchedule.emplace_back (readMappings[i].queryEndPos + 1, event::END, i);
+            eventSchedule.emplace_back (readMappings[i].queryEndPos, event::END, i);
           }
 
           std::sort(eventSchedule.begin(), eventSchedule.end());
@@ -183,7 +184,7 @@ namespace skch
 
           for(int i = 0; i < readMappings.size(); i++) {
               eventSchedule.emplace_back (readMappings[i].queryStartPos, obj.get_score(i), event::BEGIN, i);
-              eventSchedule.emplace_back (readMappings[i].queryEndPos + 1, 0, event::END, i); // end should not be preferred
+              eventSchedule.emplace_back (readMappings[i].queryEndPos, 0, event::END, i); // end should not be preferred
           }
 
           std::sort(eventSchedule.begin(), eventSchedule.end());
@@ -253,27 +254,29 @@ namespace skch
 
         Helper(MappingResultsVector_t &v) : vec(v) {}
 
+        double get_score(const int x) const {return vec[x].nucIdentity; }
+
         //Greater than comparison by score and begin position
         //used to define order in BST
-        bool operator ()(const int &x, const int &y) const {
+        bool operator ()(const int x, const int y) const {
 
           assert(x < vec.size());
           assert(y < vec.size());
 
-          auto x_score = vec[x].rlen() * vec[x].nucIdentity;
-          auto y_score = vec[y].rlen() * vec[y].nucIdentity;
+          auto x_score = get_score(x);
+          auto y_score = get_score(y);
 
           return std::tie(x_score, vec[x].refStartPos) > std::tie(y_score, vec[y].refStartPos);
         }
 
         //Greater than comparison by score
-        bool greater_score(const int &x, const int &y) {
+        bool greater_score(const int x, const int y) const {
 
           assert(x < vec.size());
           assert(y < vec.size());
 
-          auto x_score = vec[x].rlen() * vec[x].nucIdentity;
-          auto y_score = vec[y].rlen() * vec[y].nucIdentity;
+          auto x_score = get_score(x);
+          auto y_score = get_score(y);
 
           return x_score > y_score;
         }

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -97,7 +97,7 @@ float confidence_interval = 0.95;                   // Confidence interval to re
 float percentage_identity = 0.85;                   // Percent identity in the mapping step
 float ANIDiff = 0.0;                                // Stage 1 ANI diff threshold
 float ANIDiffConf = 0.999;                          // ANI diff confidence
-std::string VERSION = "3.0.7";                      // Version of MashMap
+std::string VERSION = "3.1.0";                      // Version of MashMap
 }
 }
 

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -57,6 +57,8 @@ struct Parameters
     bool skip_self;                                   //skip self mappings
     bool skip_prefix;                                 //skip mappings to sequences with the same prefix
     char prefix_delim;                                //the prefix delimiter
+    std::string target_list;  					      //file containing list of target sequences
+    std::string target_prefix; 					      //prefix for target sequences to use
     bool mergeMappings;                               //if we should merge consecutive segment mappings
     bool keep_low_pct_id;                             //true if we should keep mappings whose estimated identity < percentageIdentity
     bool report_ANI_percentage;                       //true if ANI should be in [0,100] as opposed to [0,1] (this is necessary for wfmash

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -12,6 +12,7 @@
 namespace stdfs = std::filesystem;
 
 #include "common/ALeS.hpp"
+#include "base_types.hpp"
 
 namespace skch
 {
@@ -32,12 +33,12 @@ struct Parameters
 {
     int kmerSize;                                     //kmer size for sketching
     float kmer_pct_threshold;                         //use only kmers not in the top kmer_pct_threshold %-ile
-    int64_t segLength;                                //For split mapping case, this represents the fragment length
+    offset_t segLength;                                //For split mapping case, this represents the fragment length
                                                       //for noSplit, it represents minimum read length to multimap
-    int64_t block_length;                             // minimum (potentially merged) block to keep if we aren't split
-    int64_t chain_gap;                                // max distance for 2d range union-find mapping chaining
+    offset_t block_length;                             // minimum (potentially merged) block to keep if we aren't split
+    offset_t chain_gap;                                // max distance for 2d range union-find mapping chaining
     int alphabetSize;                                 //alphabet size
-    uint64_t referenceSize;                           //Approximate reference size
+    offset_t referenceSize;                           //Approximate reference size
     float percentageIdentity;                         //user defined threshold for good similarity
     bool stage2_full_scan;                            //Instead of using the best intersection for a given candidate region, compute the minhash for every position in the window
     bool stage1_topANI_filter;                        //Use the ANI filter in stage 1

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -93,7 +93,7 @@ float confidence_interval = 0.95;                   // Confidence interval to re
 float percentage_identity = 0.85;                   // Percent identity in the mapping step
 float ANIDiff = 0.0;                                // Stage 1 ANI diff threshold
 float ANIDiffConf = 0.999;                          // ANI diff confidence
-std::string VERSION = "3.0.6";                      // Version of MashMap
+std::string VERSION = "3.0.7";                      // Version of MashMap
 }
 }
 

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -54,6 +54,7 @@ struct Parameters
     stdfs::path saveIndexFilename;                    //output file name of index
     stdfs::path loadIndexFilename;                    //input file name of index
     bool split;                                       //Split read mapping (done if this is true)
+    bool lower_triangular;                            // set to true if we should filter out half of the mappings
     bool skip_self;                                   //skip self mappings
     bool skip_prefix;                                 //skip mappings to sequences with the same prefix
     char prefix_delim;                                //the prefix delimiter

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -57,8 +57,8 @@ struct Parameters
     bool skip_self;                                   //skip self mappings
     bool skip_prefix;                                 //skip mappings to sequences with the same prefix
     char prefix_delim;                                //the prefix delimiter
-    std::string target_list;  					      //file containing list of target sequences
-    std::string target_prefix; 					      //prefix for target sequences to use
+    std::string target_list;                          //file containing list of target sequences
+    std::string target_prefix;                        //prefix for target sequences to use
     bool mergeMappings;                               //if we should merge consecutive segment mappings
     bool keep_low_pct_id;                             //true if we should keep mappings whose estimated identity < percentageIdentity
     bool report_ANI_percentage;                       //true if ANI should be in [0,100] as opposed to [0,1] (this is necessary for wfmash

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -106,6 +106,8 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
 
     cmd.defineOption("filterLengthMismatches", "Filter mappings where the ratio of reference/query mapped lengths disagrees with the ANI threshold");
 
+    cmd.defineOption("lowerTriangular", "Only map sequence i to sequence j if i > j.");
+
     cmd.defineOption("skipSelf", "skip self mappings when the query and target name is the same (for all-vs-all mode)");
     cmd.defineOptionAlternative("skipSelf", "X");
 
@@ -313,6 +315,13 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
       parameters.querySequences = parameters.refSequences;
     }
     str.clear();
+
+    if (cmd.foundOption("lowerTriangular"))
+    {
+        parameters.lower_triangular = true;
+    } else {
+        parameters.lower_triangular = false;
+    }
 
     if (cmd.foundOption("skipSelf"))
     {

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -112,6 +112,9 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     cmd.defineOption("skipPrefix", "skip mappings when the query and target have the same prefix before the last occurrence of the given character C", ArgvParser::OptionRequiresValue);
     cmd.defineOptionAlternative("skipPrefix", "Y");
 
+    cmd.defineOption("targetPrefix", "Only index reference sequences beginning with this prefix", ArgvParser::OptionRequiresValue);
+    cmd.defineOption("targetList", "file containing list of target sequence names", ArgvParser::OptionRequiresValue);
+
     cmd.defineOption("sparsifyMappings", "keep this fraction of mappings", ArgvParser::OptionRequiresValue);
     cmd.defineOptionAlternative("sparsifyMappings", "x");
 
@@ -328,8 +331,21 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
       parameters.skip_prefix = false;
       parameters.prefix_delim = '\0';
     }
-
     str.clear();
+
+    if (cmd.foundOption("targetList"))
+    {
+      str << cmd.optionValue("targetList");
+      str >> parameters.target_list;
+    }
+    str.clear();
+
+    if (cmd.foundOption("targetPrefix"))
+    {
+      str << cmd.optionValue("targetPrefix");
+      str >> parameters.target_prefix;
+    }
+
 
     if (cmd.foundOption("saveIndex")) {
         str << cmd.optionValue("saveIndex");

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -457,7 +457,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     }
 
     if (cmd.foundOption("kmerThreshold")) {
-        str << cmd.foundOption("kmerThreshold");
+        str << cmd.optionValue("kmerThreshold");
         str >> parameters.kmer_pct_threshold;
     } else {
         parameters.kmer_pct_threshold = 0.001; // in percent! so we keep 99.999% of kmers

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -146,6 +146,18 @@ namespace skch
        */
       void build()
       {
+
+        // allowed set of targets
+        std::unordered_set<std::string> allowed_target_names;
+        if (!param.target_list.empty()) {
+                std::ifstream filter_list(param.target_list);
+                std::string name;
+                while (getline(filter_list, name)) {
+                        allowed_target_names.insert(name); 
+                }
+        }
+
+
         //sequence counter while parsing file
         seqno_t seqCounter = 0;
 
@@ -168,6 +180,8 @@ namespace skch
 
         seqiter::for_each_seq_in_file(
             fileName,
+            allowed_target_names,
+            param.target_prefix,
             [&](const std::string& seq_name,
                 const std::string& seq) {
                 // todo: offset_t is an 32-bit integer, which could cause problems
@@ -197,6 +211,12 @@ namespace skch
             });
 
           sequencesByFileInfo.push_back(seqCounter);
+        }
+
+        if (seqCounter == 0)
+        {
+          std::cerr << "[mashmap::skch::Sketch::build] ERROR: No sequences indexed!" << std::endl;
+          exit(1);
         }
 
         if (param.loadIndexFilename.empty()) {


### PR DESCRIPTION
* When filtering matches, the "score" of a match no longer takes into account the length. Previously, the score for a mapping was `len*ANI`, meaning that a 1000bp mapping with 100% identity would be tossed out in favor of a 1112bp mapping with 90% identity. 
* Fixes a rare bug that caused a crash when the very first minmer in the index is a hit. 
* Fixes bug with `--kmerThreshold` CLI option which ignored users' argument in favor of `1`.
* Low complexity segments are tossed out before stage 1 mapping. 
* Mappings use 32-bit integers to store positions now instead of 64-bit integers. If you need mashmap to work with contigs larger than 2^31, you can pass  `-DLARGE_CONTIG=1`  to CMake when building. 
* Reads shorter than the block length are now split, instead of being aligned in one piece.
* Added  `--targetPrefix` and `--targetList` CLI options, which allow the users to specify subsets of the reference file to be indexed. Requires htslib!
* Added `--lowerTriangular` CLI option which only computes mappings between sequence _i_ and sequence _j_ if _i_ > _j_ (meant to be used when reference and query files are identical). 