### PR TITLE
Make htslib optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ option(LARGE_CONTIG "Use 64-bit integers instead of 32 bit for sequence coordina
 if (LARGE_CONTIG)
   add_definitions(-DLARGE_CONTIG)
 endif()
+option(USE_HTSLIB "Compile with htslib for --targetPrefix and --targetList" OFF)
+if (USE_HTSLIB)
+  add_definitions(-DUSE_HTSLIB)
+endif()
 option(PROFILE             "Prevent inlining and add debug symbols" OFF)
 
 if (${CMAKE_BUILD_TYPE} MATCHES Release)
@@ -82,22 +86,26 @@ target_link_libraries(mashmap
   gslcblas
   m
   pthread
-  hts
   #rt
   z
   #assert
 )
+if (USE_HTSLIB)
+  target_link_libraries(mashmap hts)
+endif()
 
 target_link_libraries(mashmap-align
   gsl
   gslcblas
   m
   pthread
-  hts
   #rt
   z
   #assert
 )
+if (USE_HTSLIB)
+  target_link_libraries(mashmap-align hts)
+endif()
 
 install(TARGETS mashmap DESTINATION bin)
 install(TARGETS mashmap-align DESTINATION bin)

--- a/src/common/seqiter.hpp
+++ b/src/common/seqiter.hpp
@@ -5,7 +5,9 @@
 #include <cassert>
 #include <unordered_set>
 #include "gzstream.h"
+#ifdef USE_HTSLIB
 #include <htslib/faidx.h>
+#endif
 
 namespace seqiter {
 
@@ -21,6 +23,7 @@ void for_each_seq_in_file(
     const std::string& keep_prefix,
     const std::function<void(const std::string&, const std::string&)>& func) {
 
+#ifdef USE_HTSLIB
     if ((!keep_seq.empty() || !keep_prefix.empty())
           && fai_index_exists(filename)) {
         // Use index
@@ -55,7 +58,9 @@ void for_each_seq_in_file(
             }
         }
         fai_destroy(faid); // Free FAI index
-    } else {
+    } else 
+#endif
+    {
         // no index available
         // detect file type
         bool input_is_fasta = false;


### PR DESCRIPTION
* In order to maintain a default build that requires the same libraries as previous versions, building with htslib is now optional. 
* To build with htslib, call `cmake` with `-DUSE_HTSLIB=ON`
* htslib is useful for the `--targetList` and `--targetPrefix` options, which allow users to only index specific contigs from a reference fasta file. 