### PR TITLE
Enable prefix-grouping for one-to-one filtering

### DIFF
--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -98,7 +98,7 @@ float confidence_interval = 0.95;                   // Confidence interval to re
 float percentage_identity = 0.85;                   // Percent identity in the mapping step
 float ANIDiff = 0.0;                                // Stage 1 ANI diff threshold
 float ANIDiffConf = 0.999;                          // ANI diff confidence
-std::string VERSION = "3.1.2";                      // Version of MashMap
+std::string VERSION = "3.1.3";                      // Version of MashMap
 }
 }
 


### PR DESCRIPTION
Previously, the `-f one-to-one` filter was applied to all mappings at the same time. In cases where users are mapping multiple query genomes to one or more target sequences with the `--skipPrefix #` flag, the one-to-one filter would treat all query sequences as part of the same genome, even if they had unique prefixes. 

This patch makes it so that the one-to-one plane-sweep filter is applied to each pair of query and reference groups independently, ensuring that `-n` mappings are retained for each pair. A "group" of sequences is the set of sequences which contain the same prefix up until the last occurrence of the character `c`, where `--skipPrefix c` is specified.