### PR TITLE
Better `--noSplit`

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -837,7 +837,7 @@ namespace skch
           int orig_len = Q.minmerTableQuery.size();
 #endif
           const double max_hash_01 = (long double)(Q.minmerTableQuery.back().hash) / std::numeric_limits<hash_t>::max();
-          Q.kmerComplexity = (double(Q.minmerTableQuery.size()) / max_hash_01) / ((Q.len - param.kmerSize + 1)*2);
+          Q.kmerComplexity = param.split ? 1 : (double(Q.minmerTableQuery.size()) / max_hash_01) / ((Q.len - param.kmerSize + 1)*2);
 
           // TODO remove them from the original sketch instead of removing for each read
           auto new_end = std::remove_if(Q.minmerTableQuery.begin(), Q.minmerTableQuery.end(), [&](auto& mi) {
@@ -1434,7 +1434,7 @@ namespace skch
           if (in_candidate) {
             // Save and reset
             l2_out.meanOptimalPos =  (l2_out.optimalStart + l2_out.optimalEnd) / 2;
-            //l2_out.seqId = std::prev(windowIt)->seqId;
+            l2_out.seqId = candidateLocus.seqId;
             l2_out.strand = slideMap.strand_votes >= 0 ? strnd::FWD : strnd::REV;
             if (l2_vec_out.empty() 
                 || l2_vec_out.back().optimalEnd + param.segLength < l2_out.optimalStart)
@@ -1780,8 +1780,11 @@ namespace skch
             outstrm  << sep << e.conservedSketches
                      << sep << e.blockLength
                      << sep << fakeMapQ
-                     << sep << "id:f:" << (param.report_ANI_percentage ? 100.0 : 1.0) * e.nucIdentity
-                     << sep << "kc:f:" << e.kmerComplexity;
+                     << sep << "id:f:" << (param.report_ANI_percentage ? 100.0 : 1.0) * e.nucIdentity;
+            if (param.split)
+            {
+              outstrm << sep << "kc:f:" << e.kmerComplexity;
+            }
             if (!param.mergeMappings) 
             {
               outstrm << sep << "jc:f:" << float(e.conservedSketches) / e.sketchSize;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1391,11 +1391,8 @@ namespace skch
               l2_out.sharedSketchSize = slideMap.sharedSketchElements;
 
               //Save the position
-              l2_out.optimalStart = windowIt->wpos;
-              l2_out.optimalEnd = std::next(
-                  windowIt, 
-                  windowIt != minmerIndex.end() && std::next(windowIt)->seqId == windowIt->seqId
-                )->wpos - windowLen;
+              l2_out.optimalStart = windowIt->wpos - windowLen;
+              l2_out.optimalEnd = windowIt->wpos - windowLen;
             }
             else if(slideMap.sharedSketchElements == bestSketchSize)
             {
@@ -1408,17 +1405,10 @@ namespace skch
 
               in_candidate = true;
               //Still save the position
-              l2_out.optimalEnd = std::next(
-                  windowIt, 
-                  windowIt != minmerIndex.end() && std::next(windowIt)->seqId == windowIt->seqId
-                )->wpos  - windowLen;
+              l2_out.optimalEnd = windowIt->wpos  - windowLen;
             } else {
               if (in_candidate) {
                 // Save and reset
-                l2_out.optimalEnd = std::next(
-                    windowIt, 
-                    windowIt != minmerIndex.end() && std::next(windowIt)->seqId == windowIt->seqId
-                  )->wpos - windowLen;
                 l2_out.meanOptimalPos =  (l2_out.optimalStart + l2_out.optimalEnd) / 2;
                 l2_out.seqId = windowIt->seqId;
                 l2_out.strand = prev_strand_votes >= 0 ? strnd::FWD : strnd::REV;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1411,7 +1411,7 @@ namespace skch
               if (in_candidate) {
                 // Save and reset
                 l2_out.meanOptimalPos =  (l2_out.optimalStart + l2_out.optimalEnd) / 2;
-                l2_out.seqId = windowIt->seqId;
+                l2_out.seqId = candidateLocus.seqId;
                 l2_out.strand = prev_strand_votes >= 0 ? strnd::FWD : strnd::REV;
                 if (l2_vec_out.empty() 
                     || l2_vec_out.back().optimalEnd + param.segLength < l2_out.optimalStart)
@@ -1434,7 +1434,7 @@ namespace skch
           if (in_candidate) {
             // Save and reset
             l2_out.meanOptimalPos =  (l2_out.optimalStart + l2_out.optimalEnd) / 2;
-            l2_out.seqId = std::prev(windowIt)->seqId;
+            //l2_out.seqId = std::prev(windowIt)->seqId;
             l2_out.strand = slideMap.strand_votes >= 0 ? strnd::FWD : strnd::REV;
             if (l2_vec_out.empty() 
                 || l2_vec_out.back().optimalEnd + param.segLength < l2_out.optimalStart)

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -822,6 +822,7 @@ namespace skch
           {
             CommonFunc::addMinmers(Q.minmerTableQuery, Q.seq, Q.len, param.kmerSize, param.segLength, param.alphabetSize, param.sketchSize, Q.seqCounter);
             std::sort(Q.minmerTableQuery.begin(), Q.minmerTableQuery.end(), [](const MinmerInfo& l, const MinmerInfo& r) {return l.hash < r.hash;});
+            Q.minmerTableQuery.erase(std::unique(Q.minmerTableQuery.begin(), Q.minmerTableQuery.end()), Q.minmerTableQuery.end());
           }
           else
           {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -818,15 +818,22 @@ namespace skch
         void getSeedHits(Q_Info &Q)
         {
           Q.minmerTableQuery.reserve(param.sketchSize + 1);
-          if (Q.len > 1.5 * param.segLength)
+
+          // Use global sketch of param.sketchSize if 
+          // (a) We are splitting the query into segments
+          // (b) We are not splitting the query, but we want unbiased Jaccard 
+          // (c) We are not splitting the query, but it isn't even longer than param.segLength
+          if (param.split 
+              || param.forceGlobalQuerySketch
+              || Q.len <= param.segLength)
+          {
+            CommonFunc::sketchSequence(Q.minmerTableQuery, Q.seq, Q.len, param.kmerSize, param.alphabetSize, param.sketchSize, Q.seqCounter);
+          }
+          else
           {
             CommonFunc::addMinmers(Q.minmerTableQuery, Q.seq, Q.len, param.kmerSize, param.segLength, param.alphabetSize, param.sketchSize, Q.seqCounter);
             std::sort(Q.minmerTableQuery.begin(), Q.minmerTableQuery.end(), [](const MinmerInfo& l, const MinmerInfo& r) {return l.hash < r.hash;});
             Q.minmerTableQuery.erase(std::unique(Q.minmerTableQuery.begin(), Q.minmerTableQuery.end()), Q.minmerTableQuery.end());
-          }
-          else
-          {
-            CommonFunc::sketchSequence(Q.minmerTableQuery, Q.seq, Q.len, param.kmerSize, param.alphabetSize, param.sketchSize, Q.seqCounter);
           }
           if(Q.minmerTableQuery.size() == 0) {
             Q.sketchSize = 0;

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -54,6 +54,7 @@ struct Parameters
     stdfs::path saveIndexFilename;                    //output file name of index
     stdfs::path loadIndexFilename;                    //input file name of index
     bool split;                                       //Split read mapping (done if this is true)
+    bool forceGlobalQuerySketch;                      //Use the minhash sketch for entire query even if --noSplit is used
     bool lower_triangular;                            // set to true if we should filter out half of the mappings
     bool skip_self;                                   //skip self mappings
     bool skip_prefix;                                 //skip mappings to sequences with the same prefix

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -419,6 +419,10 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     if(cmd.foundOption("noSplit"))
     {
       parameters.split = false;
+      if (parameters.stage1_topANI_filter)
+        std::cerr << "WARNING, skch::parseandSave, hypergeometric filter is incompatible with --noSplit. Disabling hypergeometric filter." << std::endl;
+
+      parameters.stage1_topANI_filter = false;
     }
     else
       parameters.split = true;

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -60,7 +60,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     cmd.defineOption("sketchSize", "Number of sketch elements", ArgvParser::OptionRequiresValue);
     cmd.defineOptionAlternative("sketchSize","J");
 
-    cmd.defineOption("dense", "Use dense sketching to yield higher ANI estimation accuracy. [disabled by default]");
+    cmd.defineOption("dense", "Use dense sketching to yield higher ANI estimation accuracy.");
 
     cmd.defineOption("blockLength", "keep merged mappings supported by homologies of at least this length [default: segmentLength]", ArgvParser::OptionRequiresValue);
     cmd.defineOptionAlternative("blockLength", "l");
@@ -77,7 +77,8 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     cmd.defineOption("loadIndex", "Prefix of index files to load, where PREFIX.map and PREFIX.index are the files to be loaded", ArgvParser::OptionRequiresValue);
 
 
-    cmd.defineOption("noSplit", "disable splitting of input sequences during mapping [enabled by default]");
+    cmd.defineOption("noSplit", "disable splitting of input sequences during mapping");
+    cmd.defineOption("unbiasedNoSplit", "same as noSplit, but uses same sketch size for each query, regardless of length. This leads to unbiased Jaccard prediction and faster mappings at a potential loss in mapping accuracy.");
 
     cmd.defineOption("perc_identity", "threshold for identity [default : 85]", ArgvParser::OptionRequiresValue);
     cmd.defineOptionAlternative("perc_identity","pi");
@@ -416,16 +417,15 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     else
       parameters.filterMode = filter::MAP;
 
-    if(cmd.foundOption("noSplit"))
+    parameters.forceGlobalQuerySketch = cmd.foundOption("unbiasedNoSplit");
+    parameters.split = !cmd.foundOption("noSplit") && !cmd.foundOption("unbiasedNoSplit");
+    if(!parameters.split)
     {
-      parameters.split = false;
       if (parameters.stage1_topANI_filter)
         std::cerr << "WARNING, skch::parseandSave, hypergeometric filter is incompatible with --noSplit. Disabling hypergeometric filter." << std::endl;
 
       parameters.stage1_topANI_filter = false;
     }
-    else
-      parameters.split = true;
 
     if(cmd.foundOption("noMerge"))
     {


### PR DESCRIPTION
To enable unbiased Jaccard estimates, the `--noSplit` option would use the same sketch size for each query, regardless of length. 

This PR makes a tradeoff which results in potential bias for the Jaccard prediction but more accurate mappings for queries that are longer than the segment length (default 5kbp). The previous behavior is still obtainable with `--unbiasedNoSplit`.

Keeping closed for now, as a better solution is likely just to use a larger sketch size.